### PR TITLE
Fix price retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
  "derive_more",
  "dioxus",
  "dioxus-desktop",
+ "form_urlencoded",
  "howlong",
  "indicatif",
  "itertools 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ derivative = "2.2.0"
 derive_more = "0.99.17"
 dioxus = { version = "0.3.2", optional = true }
 dioxus-desktop = { version = "0.3.0", optional = true }
+form_urlencoded = "1.1.0"
 howlong = { version = "0.1.7", optional = true }
 indicatif = "0.17.5"
 itertools = "0.11.0"

--- a/src/component_prices.lua
+++ b/src/component_prices.lua
@@ -1,5 +1,0 @@
-local comps = require("Module:Component costs")
-local mats = require("Module:Disassemble/mats")
-for _, mat in pairs(mats) do
-    print(string.format("%s: %.1f", mat, comps._price(mat)))
-end

--- a/src/gui/args.rs
+++ b/src/gui/args.rs
@@ -193,7 +193,7 @@ pub fn form_to_args(values: &HashMap<String, String>) -> Result<Args, String> {
             exclude,
             sort_type,
             out_file: String::from("false"),
-            price_file: String::from("false"),
+            price_file: Args::default().price_file,
             alt_count,
             limit_cpu: values.get("limit CPU").unwrap() == "true",
         },

--- a/src/perk_values.rs
+++ b/src/perk_values.rs
@@ -32,7 +32,7 @@ pub fn get_perk_values(
             }
 
             if let Some(index) = name_index_map.get(component_values.perk) {
-                let mut values: &mut PartialPerkValues =
+                let values: &mut PartialPerkValues =
                     unsafe { perk_values.get_unchecked_mut(*index) };
                 values.base += perk_base as u16;
                 values.rolls.push(perk_roll as u8);
@@ -114,7 +114,7 @@ pub fn calc_perk_rank_probabilities(
                 }
             }
 
-            let mut container = unsafe { perk_values.ranks.get_unchecked_mut(i) };
+            let container = unsafe { perk_values.ranks.get_unchecked_mut(i) };
             let range_start = i64::max(
                 container.values.threshold as i64 - perk_values.base as i64,
                 0,


### PR DESCRIPTION
As of MediaWiki version 1.40, the `scribunto-console` API has been locked behind a `csrf` token requirement (change [here](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Scribunto/+/836962)). Getting such a token seems cumbersome; instead, I'm proposing to utilise an on-wiki Lua module (specifically, `p._all_prices()` from the existing [Module:Component costs](https://runescape.wiki/w/Module:Component_costs)), meaning the tool can switch to the `parse` API to invoke it instead.

Additionally, I'm proposing that the GUI utilise the default value of the `prices_file` arg to support loading local price data in the event that wiki retrieval fails. I would prefer the GUI to also write the price data out to this file upon successful retrieval (basically, bring its behaviour in line to mirror that of the CLI), but I wasn't sure how to best accomplish that; my changes only enable the GUI to work if the wiki lookup fails and the local price data is available.

Since the current v1.7.0 version's GUI doesn't support that last bit, it is currently not usable at all; please consider releasing a new version following a merge of this PR.